### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,12 +24,7 @@
   },
   "devDependencies": {
   },
-  "license": [
-    {
-      "type" : "BSD",
-      "url" : "https://github.com/x6doooo/nsutil/raw/master/LICENSE"
-    }
-  ],
+  "license": "BSD-3-Clause",
   "engines": [
     "node >= 0.8.0"
   ],


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license